### PR TITLE
Modify: HTTP methods

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ const createError = require("http-errors");
 const app = express();
 
 const main = require("./routes/api/main");
-const attributes = require("./routes/api/attributes");
 
 const corsOptions = {
   origin: process.env.CLIENT_URL,
@@ -21,7 +20,6 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
 app.use("/", main);
-app.use("/attributes", attributes);
 
 // app.use(function (req, res, next) {
 //   next(createError(404));

--- a/routes/api/attributes.js
+++ b/routes/api/attributes.js
@@ -1,9 +1,0 @@
-const express = require("express");
-const router = express.Router();
-const attributesController = require("../controller/attributes");
-
-router.get("/", attributesController.getAttributes);
-
-router.post("/", attributesController.postAttributes);
-
-module.exports = router;

--- a/routes/api/main.js
+++ b/routes/api/main.js
@@ -1,9 +1,19 @@
 const express = require("express");
 const router = express.Router();
 const mainController = require("../controller/main");
+const attributesController = require("../controller/attributes");
+const tagsController = require("../controller/tags");
+const browserController = require("../controller/browser");
+const colorController = require("../controller/color");
 
 router.get("/", mainController.getMain);
 
-router.post("/", mainController.postMain);
+router.get("/", attributesController.getAttributes);
+
+router.get("/", tagsController.getTags);
+
+router.get("/", browserController.getBrowser);
+
+router.get("/", colorController.getColor);
 
 module.exports = router;

--- a/routes/controller/attributes.js
+++ b/routes/controller/attributes.js
@@ -1,11 +1,7 @@
 const OK = 200;
 
 function getAttributes(req, res, next) {
-  //
-}
-
-function postAttributes(req, res, next) {
   res.status(OK).json({ result: "ok" });
 }
 
-module.exports = { getAttributes, postAttributes };
+module.exports = { getAttributes };

--- a/routes/controller/browser.js
+++ b/routes/controller/browser.js
@@ -1,0 +1,7 @@
+const OK = 200;
+
+function getBrowser(req, res, next) {
+  res.status(OK).json({ result: "ok" });
+}
+
+module.exports = { getBrowser };

--- a/routes/controller/color.js
+++ b/routes/controller/color.js
@@ -1,0 +1,7 @@
+const OK = 200;
+
+function getColor(req, res, next) {
+  res.status(OK).json({ result: "ok" });
+}
+
+module.exports = { getColor };

--- a/routes/controller/tags.js
+++ b/routes/controller/tags.js
@@ -1,0 +1,7 @@
+const OK = 200;
+
+function getTags(req, res, next) {
+  res.status(OK).json({ result: "ok" });
+}
+
+module.exports = { getTags };


### PR DESCRIPTION
get 메소드를 사용하면 body를 사용할 수 없고, 사용자가 입력하는 URI의 길이가 쿼리에 붙일 수 있는 길이일지 보장이 되지 않아 (IE는 쿼리 길이 제한 존재) body data에 URI를 담아서 처리하려 POST를 처음에 입력했으나, 모든 브라우저를 지원하는 것보다는 RESTful 한 API 설계에 촛점을 맞추는 것으로 결정하여 GET으로 변경함.

closes #1, #3, #5, #7, #11